### PR TITLE
changement de la longueur maximale d'un message d'erreur

### DIFF
--- a/code_TH/TH-7KTOS.H
+++ b/code_TH/TH-7KTOS.H
@@ -23,7 +23,7 @@
            s_liberreur; structure lib erreur calculette th
 ============================================================*/
 typedef struct {
-     char    libelle[68];        /*zone libelle erreur calculette th   */
+     char    libelle[69];        /*zone libelle erreur calculette th   */
                  }
            s_liberreur  ;
 /*- fin de liberreur    :structure lib erreur calculette th  --*/


### PR DESCRIPTION
Le changement de la longueur maximale d'un message d'erreur (structure s_liberreur) de 68 à 69 permettrait de  stocker les 69 caractères (incluant le \0 final) de la chaîne du message 

5128 "th_nkdec : NaP_Plafonnement_1414_total : Majoration plafonnement < 0"

spécifié ligne 1598 de TH-7KARC.C