### PR TITLE
Une fonction 'arrondi_euro_voisin' plus équitable

### DIFF
--- a/code_TH/TH-7KARC.C
+++ b/code_TH/TH-7KARC.C
@@ -1170,7 +1170,7 @@ double arrondi_nieme_decimale_voisine(double a_arrondir, short nbdec)
 
 long arrondi_euro_inf(double a_arrondir)
 {
-    return (long)floor(( 1 + 16*DBL_EPSILON ) * a_arrondir);
+    return (long)floor(a_arrondir);
 
 }
 /*-------------------- Fin de arrondi a l'euro inferieur  --------------------*/


### PR DESCRIPTION
Actuellement la fonction 'long arrondi_euro_voisin(double a_arrondir)' retourne 2 quand on lui passe l'argument 1.499999999999999. Pourtant dans ce cas très particulier la contribuable pourrait s'attendre à ce que l'arrondi soit  1 euro.

La modification proposée permet, dans ce cas et dans d'autres, d'arrondir de manière plus équitable.